### PR TITLE
Round pixels measurement to next integer

### DIFF
--- a/zenscroll.js
+++ b/zenscroll.js
@@ -62,7 +62,7 @@
 			if (scrollContainer) {
 				return elem.offsetTop - scrollContainer.offsetTop
 			} else {
-				return elem.getBoundingClientRect().top + getScrollTop() - docElem.offsetTop
+				return Math.ceil(elem.getBoundingClientRect().top + getScrollTop() - docElem.offsetTop)
 			}
 		}
 


### PR DESCRIPTION
I noticed that using `calc()` or `vh` units in CSS may result in pixel measurements with fractions.

This means, for example, if a `<div>` has a height of 400.25px, its top will be rendered at 401px. But if we ask the browser to scroll down to 400.25px, it will stop at the closest integer, 400px. When this happens, there's a 1-pixel gap between the position we want and the position of the element.

To workaround this issue, I rounded the pixel measurement to the next integer.
