### PR TITLE
Changed browser environment detection conditional (node compatibility)

### DIFF
--- a/zenscroll.js
+++ b/zenscroll.js
@@ -48,7 +48,7 @@
 	"use strict"
 
 	// Exit if it’s not a browser environment:
-	if (!window || !document) {
+	if (typeof (window) === 'undefined' || !window.document) {
 		return {}
 	}
 


### PR DESCRIPTION
### Reason:

access to the window object is not compatible in **node** environment
`if (!window || !document) {`
`ReferenceError: window is not defined`
### Fix:

existence of window is verified with typeof operator and checked against 'undefined'.
### Note:

there are many ways to check whether or not the context is browser like, same for node; though, the fix is only to make the browser check working when executed on node, nothing more.
