### PR TITLE
Fix ids with strange characters

### DIFF
--- a/zenscroll.js
+++ b/zenscroll.js
@@ -274,7 +274,7 @@
 					defaultScroller.toY(0)
 					replaceUrl("", 0)
 				} else {
-					var targetId = anchor.hash.substring(1)
+					var targetId = decodeURI(anchor.hash.substring(1));
 					var targetElem = document.getElementById(targetId)
 					if (targetElem) {
 						event.preventDefault()


### PR DESCRIPTION
Hello.
In my html I have some ids with tildes and other characteres, for example `#introducción`. This little change fixes the id value that it's encoded by default.
Thanks for this nice project!